### PR TITLE
Refactor: switch cache to PostgreSQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "langchain-google-genai>=2.1.5",
     "langchain-anthropic>=0.3.15",
     "langchain-ollama>=0.3.3",
+    "psycopg2-binary>=2.9.9",
 ]
 
 #[tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ langchain-anthropic>=0.3.15
 langchain-ollama>=0.3.3
 numpy>=2.2.5
 orjson>=3.10.18
+psycopg2-binary>=2.9.9

--- a/src/test/test_merged_dicts.py
+++ b/src/test/test_merged_dicts.py
@@ -1,4 +1,4 @@
-from utils.util_func import deep_merge_dicts
+from ..utils.util_func import deep_merge_dicts
 
 a = {'a': 1, 'b': 2, 'c': 3, "config": {"a": 1, "b": 2, "c": 3}}
 b = {'a': 2, "config": {"a": 2, "d": 3, 'data': {"key": "value"}}}

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1,0 +1,64 @@
+"""Simple PostgreSQL helper utilities."""
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+import psycopg2
+from psycopg2.extras import RealDictCursor, execute_batch
+
+
+SCHEMA_PATH = Path("init.sql")
+DEFAULT_DSN = os.getenv(
+    "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/trading"
+)
+
+
+def init_db(conn, schema_path: Path = SCHEMA_PATH) -> None:
+    """Create tables if they do not exist."""
+    with conn.cursor() as cur, open(schema_path, "r") as f:
+        cur.execute(f.read())
+    conn.commit()
+
+
+def get_connection(dsn: str = DEFAULT_DSN):
+    """Return a PostgreSQL connection and ensure schema exists."""
+    conn = psycopg2.connect(dsn, cursor_factory=RealDictCursor)
+    init_db(conn)
+    return conn
+
+
+def _records_from_df(df, symbol: str, interval: str) -> Iterable[tuple]:
+    cols = [
+        "open_time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "close_time",
+        "quote_volume",
+        "count",
+        "taker_buy_volume",
+        "taker_buy_quote_volume",
+    ]
+    df_slice = df[cols].copy()
+    df_slice["symbol"] = symbol
+    df_slice["interval"] = interval
+    return [tuple(row) for row in df_slice.to_records(index=False)]
+
+
+def insert_price_data(df, symbol: str, interval: str, conn) -> None:
+    """Save price data DataFrame to the database."""
+    if df.empty:
+        return
+
+    records = _records_from_df(df, symbol, interval)
+    columns = (
+        "open_time, open, high, low, close, volume, close_time, quote_volume, count,"
+        " taker_buy_volume, taker_buy_quote_volume, symbol, interval"
+    )
+    query = f"INSERT INTO price_data ({columns}) VALUES (" + ",".join(["%s"] * 13) + ")"
+    with conn.cursor() as cur:
+        execute_batch(cur, query, records)
+    conn.commit()

--- a/src/utils/util_func.py
+++ b/src/utils/util_func.py
@@ -6,7 +6,7 @@ from typing import Dict, Any
 from colorama import Fore, Style
 from tabulate import tabulate
 import orjson
-from utils import QUANTITY_DECIMALS
+from .constants import QUANTITY_DECIMALS
 
 
 def import_strategy_class(strategies_path: str):


### PR DESCRIPTION
## Summary
- update database helper to use PostgreSQL
- refactor data provider query placeholders for PostgreSQL
- add psycopg2 dependency
- fix imports in util functions and tests

## Testing
- `pytest -q` *(shows only warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6857dcca98f88326afcbbb1c6565ee68