### PR TITLE
Add camel_to_snake for strategy imports

### DIFF
--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -2,6 +2,7 @@ from typing import List
 from langgraph.graph import END, StateGraph
 from graph import AgentState, StartNode, DataNode, EmptyNode, RiskManagementNode, PortfolioManagementNode
 from utils import import_strategy_class, Interval
+from utils.util_func import camel_to_snake
 
 
 class Workflow:
@@ -24,7 +25,10 @@ class Workflow:
             workflow.add_edge(node_name, "merge_data_node")
 
         for strategy_node_name in strategies:
-            strategy_class = import_strategy_class(f"src.strategies.{strategy_node_name}")
+            module_name = camel_to_snake(strategy_node_name)
+            strategy_class = import_strategy_class(
+                f"src.strategies.{module_name}.{strategy_node_name}"
+            )
             strategy_instance = strategy_class()
             workflow.add_node(strategy_node_name, strategy_instance)
             workflow.add_edge("merge_data_node", strategy_node_name)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,13 +2,15 @@ from .settings import settings
 from .constants import Interval, COLUMNS, NUMERIC_COLUMNS, QUANTITY_DECIMALS
 from .binance_data_provider import BinanceDataProvider
 from src.gateway.binance.trading_client import BinanceTradingClient
-from .util_func import (import_strategy_class,
-                        save_graph_as_png,
-                        deep_merge_dicts,
-                        parse_str_to_json,
-                        format_backtest_row,
-                        print_backtest_results
-                        )
+from .util_func import (
+    import_strategy_class,
+    camel_to_snake,
+    save_graph_as_png,
+    deep_merge_dicts,
+    parse_str_to_json,
+    format_backtest_row,
+    print_backtest_results,
+)
 
 __all__ = ['settings',
            'Interval',
@@ -18,6 +20,7 @@ __all__ = ['settings',
            'BinanceDataProvider',
            'BinanceTradingClient',
            'import_strategy_class',
+           'camel_to_snake',
            'save_graph_as_png',
            'deep_merge_dicts',
            'parse_str_to_json',

--- a/src/utils/util_func.py
+++ b/src/utils/util_func.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import re
 from langgraph.graph.state import CompiledGraph
 from langchain_core.runnables.graph import MermaidDrawMethod
 from typing import Dict, Any
@@ -16,6 +17,14 @@ def import_strategy_class(strategies_path: str):
     module_path, class_name = strategies_path.rsplit('.', 1)
     module = importlib.import_module(module_path)
     return getattr(module, class_name)
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert CamelCase string to snake_case."""
+    if not name:
+        return name
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
 def save_graph_as_png(app: CompiledGraph, output_file_path) -> None:


### PR DESCRIPTION
## Summary
- implement `camel_to_snake` helper
- export helper from utils
- update workflow to import strategies using snake case names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ef4097b48326836a43bfb6ac7ae5