### PR TITLE
Add deep_merge_dicts tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,10 @@ Key Files and Directories:
 - **src/indicators/**: Technical indicators used by strategies
 - **src/llm/**: Language model integration for decision making
 
+## Running Tests
+
+Run `pytest` from the project root to execute the unit tests.
+
 ## Contributing
 1. Fork the repository
 2. Create a feature branch

--- a/README_CN.md
+++ b/README_CN.md
@@ -488,6 +488,10 @@ ai-hedge-fund-crypto/
 - **src/indicators/**：策略使用的技术指标
 - **src/llm/**：用于决策制定的语言模型集成
 
+## 运行测试
+
+在项目根目录执行 `pytest` 即可运行单元测试。
+
 ## 贡献
 1. Fork仓库
 2. 创建功能分支

--- a/src/test/test_merged_dicts.py
+++ b/src/test/test_merged_dicts.py
@@ -1,7 +1,21 @@
+import pytest
 from ..utils.util_func import deep_merge_dicts
 
-a = {'a': 1, 'b': 2, 'c': 3, "config": {"a": 1, "b": 2, "c": 3}}
-b = {'a': 2, "config": {"a": 2, "d": 3, 'data': {"key": "value"}}}
 
-c = deep_merge_dicts(a, b)
-print(c)
+def test_deep_merge_dicts_basic():
+    a = {"a": 1, "b": 2, "c": 3, "config": {"a": 1, "b": 2, "c": 3}}
+    b = {"a": 2, "config": {"a": 2, "d": 3, "data": {"key": "value"}}}
+    expected = {
+        "a": 2,
+        "b": 2,
+        "c": 3,
+        "config": {"a": 2, "b": 2, "c": 3, "d": 3, "data": {"key": "value"}},
+    }
+    assert deep_merge_dicts(a, b) == expected
+
+
+def test_deep_merge_dicts_nested():
+    a = {"x": {"y": {"z": 1}}, "common": {"a": 1}}
+    b = {"x": {"y": {"w": 2}}, "common": {"b": 2}}
+    expected = {"x": {"y": {"z": 1, "w": 2}}, "common": {"a": 1, "b": 2}}
+    assert deep_merge_dicts(a, b) == expected


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for `deep_merge_dicts`
- document test running instructions in English and Chinese READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ef7013848326a4d2e27ba99e0cc9